### PR TITLE
Fear/20 create tree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
 	// PostgreSQL JDBC 드라이버 의존성
-//	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'org.postgresql:postgresql'
 	// h2
-	runtimeOnly 'com.h2database:h2'
+//	runtimeOnly 'com.h2database:h2'
 
 
 	// Jakarta Validation API 의존성

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	// enable production
 	implementation ("org.springframework.boot:spring-boot-starter-actuator")
 
+	// modelmapper
+	implementation 'org.modelmapper:modelmapper:2.4.4'
 }
 
 

--- a/src/main/java/com/chukapoka/server/common/authority/AppConfig.java
+++ b/src/main/java/com/chukapoka/server/common/authority/AppConfig.java
@@ -1,0 +1,15 @@
+package com.chukapoka.server.common.authority;
+
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/chukapoka/server/common/authority/SecurityConfig.java
+++ b/src/main/java/com/chukapoka/server/common/authority/SecurityConfig.java
@@ -24,7 +24,6 @@ public class SecurityConfig {
      */
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
-
     @Autowired
     private TokenRepository tokenRepository;
 
@@ -38,7 +37,7 @@ public class SecurityConfig {
                             authorizeRequests
                                     .requestMatchers("/api/user/emailCheck", "/api/user", "/api/user/authNumber", "/api/health").anonymous()
 
-                                    .requestMatchers("/api/user/logout", "api/user/reissue").hasRole(Authority.USER.getAuthority());//  hasAnyRole은 "ROLE_" 접두사를 자동으로 추가해줌 하지만 Authority는 "ROLE_USER"로 설정해야했음 이것떄문에 회원가입할떄 권한이 안넘어갔음
+                                    .requestMatchers("/api/user/logout", "api/user/reissue","/api/tree").hasRole(Authority.USER.getAuthority());//  hasAnyRole은 "ROLE_" 접두사를 자동으로 추가해줌 하지만 Authority는 "ROLE_USER"로 설정해야했음 이것떄문에 회원가입할떄 권한이 안넘어갔음
                 }
 
 

--- a/src/main/java/com/chukapoka/server/common/authority/SecurityConfig.java
+++ b/src/main/java/com/chukapoka/server/common/authority/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                             authorizeRequests
                                     .requestMatchers("/api/user/emailCheck", "/api/user", "/api/user/authNumber", "/api/health").anonymous()
 
-                                    .requestMatchers("/api/user/logout", "api/user/reissue","/api/tree").hasRole(Authority.USER.getAuthority());//  hasAnyRole은 "ROLE_" 접두사를 자동으로 추가해줌 하지만 Authority는 "ROLE_USER"로 설정해야했음 이것떄문에 회원가입할떄 권한이 안넘어갔음
+                                    .requestMatchers("/api/user/logout", "api/user/reissue","/api/tree","api/tree/**").hasRole(Authority.USER.getAuthority());//  hasAnyRole은 "ROLE_" 접두사를 자동으로 추가해줌 하지만 Authority는 "ROLE_USER"로 설정해야했음 이것떄문에 회원가입할떄 권한이 안넘어갔음
                 }
 
 

--- a/src/main/java/com/chukapoka/server/common/enums/TreeType.java
+++ b/src/main/java/com/chukapoka/server/common/enums/TreeType.java
@@ -1,8 +1,30 @@
 package com.chukapoka.server.common.enums;
 
-public enum TreeType {
-    MINE,
-    NOT_YET_SEND;
+import lombok.Getter;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public enum TreeType {
+    MINE("내트리"),
+    NOT_YET_SEND("미부여 트리");
+
+    private final String description;
+    private static final Map<String, TreeType> lookup = new HashMap<>();
+
+    static {
+        for (TreeType treeType : TreeType.values()) {
+            lookup.put(treeType.getDescription(), treeType);
+        }
+    }
+
+    TreeType(String description) {
+        this.description = description;
+    }
+
+    public static TreeType getByDescription(String description) {
+        return lookup.get(description);
+    }
 
 }

--- a/src/main/java/com/chukapoka/server/common/enums/TreeType.java
+++ b/src/main/java/com/chukapoka/server/common/enums/TreeType.java
@@ -1,0 +1,8 @@
+package com.chukapoka.server.common.enums;
+
+public enum TreeType {
+    MINE,
+    NOT_YET_SEND;
+
+
+}

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -1,0 +1,10 @@
+package com.chukapoka.server.tree.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tree")
+public class TreeController {
+}
+

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -1,10 +1,42 @@
 package com.chukapoka.server.tree.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.chukapoka.server.common.dto.BaseResponse;
+import com.chukapoka.server.common.enums.ResultType;
+import com.chukapoka.server.tree.entity.Tree;
+import com.chukapoka.server.tree.service.TreeService;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
+@AllArgsConstructor
 @RequestMapping("/api/tree")
 public class TreeController {
+
+    @Autowired
+    private final TreeService treeService ;
+
+    /**트리 생성 */
+    @PostMapping
+    public BaseResponse<Tree>createTree(@RequestBody Tree tree) {
+        Tree response = treeService.createTree(tree);
+        return new BaseResponse<>(ResultType.SUCCESS, response);
+    }
+
+    /** 트리리스트 목록 */
+    @GetMapping
+    private BaseResponse<List<Tree>> treeList(@RequestParam("id") Long userId) {
+        List<Tree> response = treeService.treeList(userId);
+        return new BaseResponse<>(ResultType.SUCCESS, response);
+    }
+
+    /** 트리 삭제 */
+    @DeleteMapping
+    private BaseResponse<Void> deleteTree(@RequestParam("treeId") Long treeId) {
+        treeService.deleteTree(treeId);
+        return new BaseResponse<>(ResultType.SUCCESS, null);
+    }
 }
 

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -2,8 +2,9 @@ package com.chukapoka.server.tree.controller;
 
 import com.chukapoka.server.common.dto.BaseResponse;
 import com.chukapoka.server.common.enums.ResultType;
+import com.chukapoka.server.tree.dto.TreeDetailResponseDto;
 import com.chukapoka.server.tree.dto.TreeListResponseDto;
-import com.chukapoka.server.tree.dto.TreeRequestDto;
+import com.chukapoka.server.tree.dto.TreeCreateRequestDto;
 import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.service.TreeService;
@@ -24,7 +25,7 @@ public class TreeController {
 
     /**트리 생성 */
     @PostMapping
-    public BaseResponse<Tree>createTree(@Valid @RequestBody TreeRequestDto treeRequestDto) {
+    public BaseResponse<Tree>createTree(@Valid @RequestBody TreeCreateRequestDto treeRequestDto) {
         Tree responseDto = treeService.createTree(treeRequestDto);
         return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
@@ -36,19 +37,26 @@ public class TreeController {
         return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
 
+    /** 트리상세 정보 */
+    @GetMapping("/{treeId}")
+    private BaseResponse<TreeDetailResponseDto> treeDetail(@PathVariable("treeId") Long treeId) {
+        TreeDetailResponseDto responseDto = treeService.treeDetail(treeId);
+        return new BaseResponse<>(ResultType.SUCCESS, responseDto);
+    }
+
     /** 트리 수정 */
     @PutMapping("/{treeId}")
     public BaseResponse<Tree> treeModify(@PathVariable("treeId") Long treeId,
                                          @RequestBody TreeModifyRequestDto treeModifyDto) {
-        System.out.println("treeModifyDto = " + treeModifyDto);
         Tree responseDto = treeService.treeModify(treeId, treeModifyDto);
         return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
 
+
     /** 트리 삭제 */
     @DeleteMapping("/{treeId}")
-    public BaseResponse<Void> deleteTree(@PathVariable("treeId") Long treeId) {
-        treeService.deleteTree(treeId);
+    public BaseResponse<Void> treeDelete(@PathVariable("treeId") Long treeId) {
+        treeService.treeDelete(treeId);
         return new BaseResponse<>(ResultType.SUCCESS, null);
     }
 

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -60,5 +60,7 @@ public class TreeController {
         return new BaseResponse<>(ResultType.SUCCESS, null);
     }
 
+
+
 }
 

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -4,6 +4,7 @@ import com.chukapoka.server.common.dto.BaseResponse;
 import com.chukapoka.server.common.enums.ResultType;
 import com.chukapoka.server.tree.dto.TreeListResponseDto;
 import com.chukapoka.server.tree.dto.TreeRequestDto;
+import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.service.TreeService;
 import jakarta.validation.Valid;
@@ -11,7 +12,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+
 
 @RestController
 @AllArgsConstructor
@@ -35,6 +36,14 @@ public class TreeController {
         return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
 
+    /** 트리 수정 */
+    @PutMapping("/{treeId}")
+    public BaseResponse<Tree> treeModify(@PathVariable("treeId") Long treeId,
+                                         @RequestBody TreeModifyRequestDto treeModifyDto) {
+        System.out.println("treeModifyDto = " + treeModifyDto);
+        Tree responseDto = treeService.treeModify(treeId, treeModifyDto);
+        return new BaseResponse<>(ResultType.SUCCESS, responseDto);
+    }
 
     /** 트리 삭제 */
     @DeleteMapping("/{treeId}")
@@ -42,5 +51,6 @@ public class TreeController {
         treeService.deleteTree(treeId);
         return new BaseResponse<>(ResultType.SUCCESS, null);
     }
+
 }
 

--- a/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
+++ b/src/main/java/com/chukapoka/server/tree/controller/TreeController.java
@@ -2,8 +2,11 @@ package com.chukapoka.server.tree.controller;
 
 import com.chukapoka.server.common.dto.BaseResponse;
 import com.chukapoka.server.common.enums.ResultType;
+import com.chukapoka.server.tree.dto.TreeListResponseDto;
+import com.chukapoka.server.tree.dto.TreeRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.service.TreeService;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -20,21 +23,22 @@ public class TreeController {
 
     /**트리 생성 */
     @PostMapping
-    public BaseResponse<Tree>createTree(@RequestBody Tree tree) {
-        Tree response = treeService.createTree(tree);
-        return new BaseResponse<>(ResultType.SUCCESS, response);
+    public BaseResponse<Tree>createTree(@Valid @RequestBody TreeRequestDto treeRequestDto) {
+        Tree responseDto = treeService.createTree(treeRequestDto);
+        return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
 
     /** 트리리스트 목록 */
     @GetMapping
-    private BaseResponse<List<Tree>> treeList(@RequestParam("id") Long userId) {
-        List<Tree> response = treeService.treeList(userId);
-        return new BaseResponse<>(ResultType.SUCCESS, response);
+    public BaseResponse<TreeListResponseDto> treeList() {
+        TreeListResponseDto responseDto = treeService.treeList();
+        return new BaseResponse<>(ResultType.SUCCESS, responseDto);
     }
 
+
     /** 트리 삭제 */
-    @DeleteMapping
-    private BaseResponse<Void> deleteTree(@RequestParam("treeId") Long treeId) {
+    @DeleteMapping("/{treeId}")
+    public BaseResponse<Void> deleteTree(@PathVariable("treeId") Long treeId) {
         treeService.deleteTree(treeId);
         return new BaseResponse<>(ResultType.SUCCESS, null);
     }

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeCreateRequestDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeCreateRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class TreeRequestDto {
+public class TreeCreateRequestDto {
     @NotBlank(message = "title is null")
     private String title;
     @NotNull(message = "treeType is null")
@@ -17,7 +17,7 @@ public class TreeRequestDto {
     private String linkId;
     @NotBlank(message = "sendId is null")
     private String sendId;
-    private Long updatedBy;  // 클라이언트에서는 입력받을 필요없음
+    private Long updatedBy;  // 클라이언트에서는 입력받을 필요없음 ( TreeServicelmpl.createTree 에서 처리 )
     private String treeBgColor;
     private String groundColor;
     private String treeTopColor;

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeDetailResponseDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeDetailResponseDto.java
@@ -1,5 +1,7 @@
 package com.chukapoka.server.tree.dto;
 
+
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,17 +11,23 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class TreeList {
+public class TreeDetailResponseDto {
 
-    /** 트리 리스트정보 */
+    /** 트리상세 정보 */
     private Long treeId;
     private String title;
     private String type; // MINE or NOT_YEN_SEND
-    private String linkId;
-    private String sendId;
+    private String treeBgColor;
+    private String groundColor;
+    private String treeTopColor;
+    private String treeItemColor;
+    private String treeBottomColor;
+
+    /** treeItem 목록 필요 */
+
     private Long updatedBy;
     private LocalDateTime updatedAt;
 
-    /** 트리색상 부분 추가 가능 */
+
 
 }

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeList.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeList.java
@@ -1,0 +1,25 @@
+package com.chukapoka.server.tree.dto;
+
+import com.chukapoka.server.common.enums.TreeType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TreeList {
+
+    private Long treeId;
+    private String title;
+    private String type; // MINE or NOT_YEN_SEND
+    private String linkId;
+    private String sendId;
+    private Long updatedBy;
+    private LocalDateTime updatedAt;
+
+    /** 트리색상 부분 추가 가능 */
+
+}

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
@@ -1,9 +1,4 @@
 package com.chukapoka.server.tree.dto;
-
-
-
-
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class TreeListResponseDto {
 
     /** 트리 리스트 목록 */
-    private List<TreeList> trees;
+    private List<TreeList> treeList;
 }
 
 

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeListResponseDto.java
@@ -1,0 +1,22 @@
+package com.chukapoka.server.tree.dto;
+
+
+
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TreeListResponseDto {
+
+    /** 트리 리스트 목록 */
+    private List<TreeList> trees;
+}
+
+

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeModifyRequestDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeModifyRequestDto.java
@@ -4,6 +4,8 @@ import lombok.Data;
 
 @Data
 public class TreeModifyRequestDto {
+
+    /** 트리에 관련된 것만 수정할것인지 ?*/
     private String title;
     private String type;
     private String treeBgColor;
@@ -11,4 +13,5 @@ public class TreeModifyRequestDto {
     private String treeTopColor;
     private String treeItemColor;
     private String treeBottomColor;
+    
 }

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeModifyRequestDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeModifyRequestDto.java
@@ -1,0 +1,14 @@
+package com.chukapoka.server.tree.dto;
+
+import lombok.Data;
+
+@Data
+public class TreeModifyRequestDto {
+    private String title;
+    private String type;
+    private String treeBgColor;
+    private String groundColor;
+    private String treeTopColor;
+    private String treeItemColor;
+    private String treeBottomColor;
+}

--- a/src/main/java/com/chukapoka/server/tree/dto/TreeRequestDto.java
+++ b/src/main/java/com/chukapoka/server/tree/dto/TreeRequestDto.java
@@ -1,0 +1,26 @@
+package com.chukapoka.server.tree.dto;
+
+import com.chukapoka.server.common.annotation.ValidEnum;
+import com.chukapoka.server.common.enums.TreeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class TreeRequestDto {
+    @NotBlank(message = "title is null")
+    private String title;
+    @NotNull(message = "treeType is null")
+    @ValidEnum(enumClass = TreeType.class, message = "TreeType must be MINE or NOT_YET_SEND")
+    private String type;
+    @NotBlank(message = "linkId is null")
+    private String linkId;
+    @NotBlank(message = "sendId is null")
+    private String sendId;
+    private Long updatedBy;  // 클라이언트에서는 입력받을 필요없음
+    private String treeBgColor;
+    private String groundColor;
+    private String treeTopColor;
+    private String treeItemColor;
+    private String treeBottomColor;
+}

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -1,0 +1,43 @@
+package com.chukapoka.server.tree.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "tb_tree")
+public class Tree {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "treeId")
+    private Long id;
+    @Column(name = "linkId", nullable = false)
+    private String linkId;
+    @Column(name = "sendId", nullable = false)
+    private String sendId;
+    @Column(name = "title", nullable = false)
+    private String title;
+    @Column(name = "updateAt", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Tree(Long id, String linkId, String sendId, String title, LocalDateTime updatedAt) {
+        this.id = id;
+        this.linkId = linkId;
+        this.sendId = sendId;
+        this.title = title;
+        this.updatedAt = updatedAt;
+    }
+    //    private String type;
+//    private String treeBgColor;
+//    private String groundColor;
+//    private String treeTopColor;
+//    private String treeItemColor;
+//    private String treeBottomColor;
+
+}

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -1,6 +1,8 @@
 package com.chukapoka.server.tree.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Data
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "tb_tree")
 public class Tree {
@@ -16,28 +19,47 @@ public class Tree {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "treeId")
     private Long id;
-    @Column(name = "linkId", nullable = false)
-    private String linkId;
-    @Column(name = "sendId", nullable = false)
-    private String sendId;
+
+    /** 트리제목 */
     @Column(name = "title", nullable = false)
     private String title;
-    @Column(name = "updateAt", nullable = false)
+
+    /** 내트리 || 미부여 트리 */
+    @Column(name = "type", nullable = false)
+    private String type;
+
+    /** 트리 링크를 특정하기 위한 id*/
+    @Column(name = "linkId", nullable = false, unique = true, length = 200)
+    private String linkId;
+
+    /** 타인에게 트리를 전달할 때 트리를 특정하기 위한 id */
+    @Column(name = "sendId", unique = true, length = 200)
+    private String sendId;
+
+    /** 트라 관련 색상은 String -> enum type으로 상수로 바꿔야 관리가 더 편할것같음 */
+    @Column(name = "treeBgColor", nullable = true)
+    private String treeBgColor;
+
+    @Column(name = "groundColor", nullable = true)
+    private String groundColor;
+
+    @Column(name = "treeTopColor", nullable = true)
+    private String treeTopColor;
+
+    @Column(name = "treeItemColor", nullable = true)
+    private String treeItemColor;
+
+    @Column(name = "treeBottomColor", nullable = true)
+    private String treeBottomColor;
+
+    /** userId가 값임 */
+    @Column(name = "updatedBy", nullable = false)
+    private String updatedBy;
+    /** 생성 시간 */
+    @Column(name = "updatedAt", nullable = false)
     private LocalDateTime updatedAt;
 
-    @Builder
-    public Tree(Long id, String linkId, String sendId, String title, LocalDateTime updatedAt) {
-        this.id = id;
-        this.linkId = linkId;
-        this.sendId = sendId;
-        this.title = title;
-        this.updatedAt = updatedAt;
-    }
-    //    private String type;
-//    private String treeBgColor;
-//    private String groundColor;
-//    private String treeTopColor;
-//    private String treeItemColor;
-//    private String treeBottomColor;
+
+
 
 }

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -39,15 +39,6 @@ public class Tree {
     @Column(name = "sendId", unique = true, length = 200)
     private String sendId;
 
-    /** userId가 값임 */
-    @Column(name = "updatedBy")
-    private Long updatedBy;
-
-    /** 생성 시간 */
-    @Column(name = "updatedAt", nullable = false)
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
     /** 트라 관련 색상은 String -> enum type으로 상수로 바꿔야 관리가 더 편할것같음 */
     @Column(name = "treeBgColor", nullable = true)
     private String treeBgColor;
@@ -64,11 +55,21 @@ public class Tree {
     @Column(name = "treeBottomColor", nullable = true)
     private String treeBottomColor;
 
+    /** userId가 값임 */
+    @Column(name = "updatedBy")
+    private Long updatedBy;
+
+    /** 생성 시간 */
+    @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
 
 
     @PrePersist
     public void updatedAt() {
         this.updatedAt = LocalDateTime.now();
     }
+
 
 }

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -1,11 +1,12 @@
 package com.chukapoka.server.tree.entity;
 
-import com.chukapoka.server.common.enums.TreeType;
 
 import jakarta.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate // 데이터의 변경사항이 있는 것만 수정
 @Table(name = "tb_tree")
 public class Tree {
     @Id
@@ -22,11 +24,11 @@ public class Tree {
     private Long treeId;
 
     /** 트리제목 */
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
     /** 내트리 || 미부여 트리 */
-    @Column(name = "type", nullable = false)
+    @Column(name = "type")
     private String type;
 
     /** 트리 링크를 특정하기 위한 id*/

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -26,9 +26,8 @@ public class Tree {
     private String title;
 
     /** 내트리 || 미부여 트리 */
-    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    private TreeType type;
+    private String type;
 
     /** 트리 링크를 특정하기 위한 id*/
     @Column(name = "linkId", nullable = false, unique = true, length = 200)
@@ -37,6 +36,15 @@ public class Tree {
     /** 타인에게 트리를 전달할 때 트리를 특정하기 위한 id */
     @Column(name = "sendId", unique = true, length = 200)
     private String sendId;
+
+    /** userId가 값임 */
+    @Column(name = "updatedBy")
+    private Long updatedBy;
+
+    /** 생성 시간 */
+    @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     /** 트라 관련 색상은 String -> enum type으로 상수로 바꿔야 관리가 더 편할것같음 */
     @Column(name = "treeBgColor", nullable = true)
@@ -54,14 +62,7 @@ public class Tree {
     @Column(name = "treeBottomColor", nullable = true)
     private String treeBottomColor;
 
-    /** userId가 값임 */
-    @Column(name = "updatedBy")
-    private Long updatedBy;
 
-    /** 생성 시간 */
-    @Column(name = "updatedAt", nullable = false)
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     @PrePersist
     public void updatedAt() {

--- a/src/main/java/com/chukapoka/server/tree/entity/Tree.java
+++ b/src/main/java/com/chukapoka/server/tree/entity/Tree.java
@@ -1,11 +1,12 @@
 package com.chukapoka.server.tree.entity;
 
+import com.chukapoka.server.common.enums.TreeType;
+
 import jakarta.persistence.*;
-import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -18,15 +19,16 @@ public class Tree {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "treeId")
-    private Long id;
+    private Long treeId;
 
     /** 트리제목 */
     @Column(name = "title", nullable = false)
     private String title;
 
     /** 내트리 || 미부여 트리 */
+    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    private String type;
+    private TreeType type;
 
     /** 트리 링크를 특정하기 위한 id*/
     @Column(name = "linkId", nullable = false, unique = true, length = 200)
@@ -53,13 +55,17 @@ public class Tree {
     private String treeBottomColor;
 
     /** userId가 값임 */
-    @Column(name = "updatedBy", nullable = false)
-    private String updatedBy;
+    @Column(name = "updatedBy")
+    private Long updatedBy;
+
     /** 생성 시간 */
     @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
-
-
+    @PrePersist
+    public void updatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
+++ b/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
@@ -4,9 +4,8 @@ import com.chukapoka.server.tree.entity.Tree;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface TreeRepository extends JpaRepository<Tree, String> {
     Tree findById(Long treeId);
+    void delete(Long treeId);
 }

--- a/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
+++ b/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
@@ -1,0 +1,12 @@
+package com.chukapoka.server.tree.repository;
+
+import com.chukapoka.server.tree.entity.Tree;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TreeRepository extends JpaRepository<Tree, String> {
+    Tree findById(Long treeId);
+}

--- a/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
+++ b/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
@@ -1,10 +1,12 @@
 package com.chukapoka.server.tree.repository;
 
+
+import com.chukapoka.server.tree.dto.TreeList;
 import com.chukapoka.server.tree.entity.Tree;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
 
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +14,8 @@ import java.util.Optional;
 @Repository
 public interface TreeRepository extends JpaRepository<Tree, Long> {
     Optional<Tree> findById(Long treeId);
+    @Query("SELECT new com.chukapoka.server.tree.dto.TreeList(tree.treeId, tree.title, tree.type, tree.linkId, tree.sendId, tree.updatedBy, tree.updatedAt) FROM Tree tree")
+    List<TreeList> findAllTrees();
 
-    List<Tree> findByUpdatedBy(Long userId);
+
 }

--- a/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
+++ b/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
@@ -1,11 +1,17 @@
 package com.chukapoka.server.tree.repository;
 
 import com.chukapoka.server.tree.entity.Tree;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface TreeRepository extends JpaRepository<Tree, String> {
-    Tree findById(Long treeId);
-    void delete(Long treeId);
+public interface TreeRepository extends JpaRepository<Tree, Long> {
+    Optional<Tree> findById(Long treeId);
+
+    List<Tree> findByUpdatedBy(Long userId);
 }

--- a/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
+++ b/src/main/java/com/chukapoka/server/tree/repository/TreeRepository.java
@@ -1,6 +1,7 @@
 package com.chukapoka.server.tree.repository;
 
 
+
 import com.chukapoka.server.tree.dto.TreeList;
 import com.chukapoka.server.tree.entity.Tree;
 

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -1,25 +1,26 @@
 package com.chukapoka.server.tree.service;
 
+import com.chukapoka.server.tree.dto.TreeDetailResponseDto;
 import com.chukapoka.server.tree.dto.TreeListResponseDto;
-import com.chukapoka.server.tree.dto.TreeRequestDto;
+import com.chukapoka.server.tree.dto.TreeCreateRequestDto;
 import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 
 public interface TreeService {
 
     /** 트리 저장 */
-    Tree createTree(TreeRequestDto treeRequestDto);
+    Tree createTree(TreeCreateRequestDto treeRequestDto);
 
     /** 트리리스트 조회(리스트용 모델) */
     TreeListResponseDto treeList();
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
-    Tree treeDetail(Long treeId);
+    TreeDetailResponseDto treeDetail(Long treeId);
 
     /** 트리 수정 */
     Tree treeModify(Long treeId, TreeModifyRequestDto treeModifyDto);
 
     /** 트리 삭제 */
-    void deleteTree(Long treeId);
+    void treeDelete(Long treeId);
 
 }

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -6,12 +6,18 @@ import java.util.List;
 
 public interface TreeService {
 
-    // 회원 아이디로 트리 아이템 저장
-    Tree createTree( Tree tree);
+    /** 트리 저장 */
+    Tree createTree(Tree tree);
 
-    // 트리 리스트 조회
+    /** 트리리스트 조회(리스트용 모델) */
     List<Tree> TreeList();
 
-    // 트리 삭제
-    void deleteTree(String treeId);
+    /**
+     * 트리 상세 정보 조회 (상세정보 모델)
+     */
+    Tree TreeDetail(Long treeId);
+
+    /** 트리 삭제 */
+    void deleteTree(Long treeId);
+
 }

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -1,5 +1,7 @@
 package com.chukapoka.server.tree.service;
 
+import com.chukapoka.server.tree.dto.TreeListResponseDto;
+import com.chukapoka.server.tree.dto.TreeRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 
 import java.util.List;
@@ -7,10 +9,10 @@ import java.util.List;
 public interface TreeService {
 
     /** 트리 저장 */
-    Tree createTree(Tree tree);
+    Tree createTree(TreeRequestDto treeRequestDto);
 
     /** 트리리스트 조회(리스트용 모델) */
-    List<Tree> treeList(Long userId);
+    TreeListResponseDto treeList();
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
     Tree treeDetail(Long treeId);

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -1,0 +1,17 @@
+package com.chukapoka.server.tree.service;
+
+import com.chukapoka.server.tree.entity.Tree;
+
+import java.util.List;
+
+public interface TreeService {
+
+    // 회원 아이디로 트리 아이템 저장
+    Tree createTree( Tree tree);
+
+    // 트리 리스트 조회
+    List<Tree> TreeList();
+
+    // 트리 삭제
+    void deleteTree(String treeId);
+}

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -10,12 +10,10 @@ public interface TreeService {
     Tree createTree(Tree tree);
 
     /** 트리리스트 조회(리스트용 모델) */
-    List<Tree> TreeList();
+    List<Tree> treeList(Long userId);
 
-    /**
-     * 트리 상세 정보 조회 (상세정보 모델)
-     */
-    Tree TreeDetail(Long treeId);
+    /** 트리 상세 정보 조회 (상세정보 모델) */
+    Tree treeDetail(Long treeId);
 
     /** 트리 삭제 */
     void deleteTree(Long treeId);

--- a/src/main/java/com/chukapoka/server/tree/service/TreeService.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeService.java
@@ -2,9 +2,8 @@ package com.chukapoka.server.tree.service;
 
 import com.chukapoka.server.tree.dto.TreeListResponseDto;
 import com.chukapoka.server.tree.dto.TreeRequestDto;
+import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
-
-import java.util.List;
 
 public interface TreeService {
 
@@ -16,6 +15,9 @@ public interface TreeService {
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
     Tree treeDetail(Long treeId);
+
+    /** 트리 수정 */
+    Tree treeModify(Long treeId, TreeModifyRequestDto treeModifyDto);
 
     /** 트리 삭제 */
     void deleteTree(Long treeId);

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -4,10 +4,12 @@ import com.chukapoka.server.common.dto.CustomUser;
 import com.chukapoka.server.tree.dto.TreeList;
 import com.chukapoka.server.tree.dto.TreeListResponseDto;
 import com.chukapoka.server.tree.dto.TreeRequestDto;
+import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.repository.TreeRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.AllArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.BeanUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -21,16 +23,16 @@ import java.util.List;
 public class TreeServiceImpl implements TreeService{
 
     private final TreeRepository treeRepository;
-
+    private final ModelMapper modelMapper;
 
     /** 트리생성 */
     @Override
     @Transactional
     public Tree createTree(TreeRequestDto treeRequestDto) {
-        long userId = ((CustomUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
-        // 클라이언트에서 입력 받을 필요없이 토큰으로 접속후 권한id로 셋팅
-        treeRequestDto.setUpdatedBy(userId);
         Tree tree = new Tree();
+        // 클라이언트에서 입력 받을 필요없이 토큰으로 접속후 권한id로 셋팅
+        long userId = ((CustomUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
+        treeRequestDto.setUpdatedBy(userId);
         BeanUtils.copyProperties(treeRequestDto, tree); // mapper대신 사용할수 있지만 복사할 속성의 수가 적고 속성 이름이 일치하는 경우에 적합
         return treeRepository.save(tree);
     }
@@ -48,7 +50,20 @@ public class TreeServiceImpl implements TreeService{
     /** 트리 상세 정보 조회 (상세정보 모델) */
     @Override
     public Tree treeDetail(Long treeId) {
+
         return null;
+    }
+
+    /** 트리수정 */
+    @Override
+    @Transactional // 데이터 변경감지
+    public Tree treeModify(Long treeId, TreeModifyRequestDto treeModifyDto) {
+        // 트리 아이디로 트리를 찾음
+        Tree tree = treeRepository.findById(treeId)
+                .orElseThrow(() -> new EntityNotFoundException("treeId " + treeId + " 를 찾을 수 없습니다."));
+        updateTreeAttributes(tree, treeModifyDto);
+        return treeRepository.save(tree);
+
     }
 
     /** 트리 삭제 */
@@ -61,5 +76,14 @@ public class TreeServiceImpl implements TreeService{
     }
 
 
-
+    /** 트리필드 정보 업데이트 */
+    private void updateTreeAttributes(Tree tree, TreeModifyRequestDto treeModifyDto) {
+        tree.setTitle(treeModifyDto.getTitle());
+        tree.setType(treeModifyDto.getType());
+        tree.setTreeBgColor(treeModifyDto.getTreeBgColor());
+        tree.setGroundColor(treeModifyDto.getGroundColor());
+        tree.setTreeTopColor(treeModifyDto.getTreeTopColor());
+        tree.setTreeItemColor(treeModifyDto.getTreeItemColor());
+        tree.setTreeBottomColor(treeModifyDto.getTreeBottomColor());
+    }
 }

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -1,12 +1,10 @@
 package com.chukapoka.server.tree.service;
 
+import com.chukapoka.server.common.dto.CustomUser;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.repository.TreeRepository;
-import com.chukapoka.server.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,35 +15,32 @@ public class TreeServiceImpl implements TreeService{
 
     private final TreeRepository treeRepository;
 
-
     /** 트리생성 */
     @Override
     public Tree createTree(Tree tree) {
-
+        long userId = ((CustomUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
+        tree.setUpdatedBy(userId);
         return treeRepository.save(tree);
     }
 
-    /** 사용자 트리 리스트 조화(리스트용 모델) */
+    /**사용자 트리 리스트 조화(리스트용 모델) */
     @Override
-    public List<Tree> TreeList() {
-        return null;
+    public List<Tree> treeList(Long userId) {
+        return treeRepository.findByUpdatedBy(userId);
     }
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
     @Override
-    public Tree TreeDetail(Long treeId) {
+    public Tree treeDetail(Long treeId) {
         return null;
     }
 
     /** 트리 삭제 */
     @Override
     public void deleteTree(Long treeId) {
-        treeRepository.delete(treeId);
+        treeRepository.deleteById(treeId);
     }
 
-    /** 사용자 ID 반환 메서드 */
-    private String getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication.getName();
-    }
+
+
 }

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -2,7 +2,11 @@ package com.chukapoka.server.tree.service;
 
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.repository.TreeRepository;
+import com.chukapoka.server.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,21 +17,35 @@ public class TreeServiceImpl implements TreeService{
 
     private final TreeRepository treeRepository;
 
+
     /** 트리생성 */
     @Override
     public Tree createTree(Tree tree) {
-        return null;
+
+        return treeRepository.save(tree);
     }
 
-    /** 사용자 트리 리스트 */
+    /** 사용자 트리 리스트 조화(리스트용 모델) */
     @Override
     public List<Tree> TreeList() {
         return null;
     }
 
+    /** 트리 상세 정보 조회 (상세정보 모델) */
+    @Override
+    public Tree TreeDetail(Long treeId) {
+        return null;
+    }
+
     /** 트리 삭제 */
     @Override
-    public void deleteTree(String treeId) {
+    public void deleteTree(Long treeId) {
+        treeRepository.delete(treeId);
+    }
 
+    /** 사용자 ID 반환 메서드 */
+    private String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
     }
 }

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -1,0 +1,33 @@
+package com.chukapoka.server.tree.service;
+
+import com.chukapoka.server.tree.entity.Tree;
+import com.chukapoka.server.tree.repository.TreeRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class TreeServiceImpl implements TreeService{
+
+    private final TreeRepository treeRepository;
+
+    /** 트리생성 */
+    @Override
+    public Tree createTree(Tree tree) {
+        return null;
+    }
+
+    /** 사용자 트리 리스트 */
+    @Override
+    public List<Tree> TreeList() {
+        return null;
+    }
+
+    /** 트리 삭제 */
+    @Override
+    public void deleteTree(String treeId) {
+
+    }
+}

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -1,12 +1,19 @@
 package com.chukapoka.server.tree.service;
 
 import com.chukapoka.server.common.dto.CustomUser;
+import com.chukapoka.server.tree.dto.TreeList;
+import com.chukapoka.server.tree.dto.TreeListResponseDto;
+import com.chukapoka.server.tree.dto.TreeRequestDto;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.repository.TreeRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.BeanUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,18 +22,27 @@ public class TreeServiceImpl implements TreeService{
 
     private final TreeRepository treeRepository;
 
+
     /** 트리생성 */
     @Override
-    public Tree createTree(Tree tree) {
+    @Transactional
+    public Tree createTree(TreeRequestDto treeRequestDto) {
         long userId = ((CustomUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
-        tree.setUpdatedBy(userId);
+        // 클라이언트에서 입력 받을 필요없이 토큰으로 접속후 권한id로 셋팅
+        treeRequestDto.setUpdatedBy(userId);
+        Tree tree = new Tree();
+        BeanUtils.copyProperties(treeRequestDto, tree); // mapper대신 사용할수 있지만 복사할 속성의 수가 적고 속성 이름이 일치하는 경우에 적합
         return treeRepository.save(tree);
     }
 
-    /**사용자 트리 리스트 조화(리스트용 모델) */
+    /** 사용자 트리 리스트 조회(리스트용 모델) */
     @Override
-    public List<Tree> treeList(Long userId) {
-        return treeRepository.findByUpdatedBy(userId);
+    public TreeListResponseDto treeList() {
+        List<TreeList> trees = treeRepository.findAllTrees();
+        if (trees.isEmpty()) {
+            return new TreeListResponseDto(new ArrayList<>());
+        }
+        return new TreeListResponseDto(trees);
     }
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
@@ -37,7 +53,10 @@ public class TreeServiceImpl implements TreeService{
 
     /** 트리 삭제 */
     @Override
+    @Transactional
     public void deleteTree(Long treeId) {
+        treeRepository.findById(treeId)
+                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 " + treeId + "입니다."));
         treeRepository.deleteById(treeId);
     }
 

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -34,6 +34,7 @@ public class TreeServiceImpl implements TreeService{
         // -> 서버에서 linkId, sendId를 만들어줄꺼라면 build가 좋을꺼같은데...
         BeanUtils.copyProperties(treeRequestDto, tree); // mapper대신 사용할수 있지만 복사할 속성의 수가 적고 속성 이름이 일치하는 경우에 적합
         return treeRepository.save(tree);
+        
     }
 
     /** 사용자 트리 리스트 조회(리스트용 모델) */

--- a/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/chukapoka/server/tree/service/TreeServiceImpl.java
@@ -1,10 +1,7 @@
 package com.chukapoka.server.tree.service;
 
 import com.chukapoka.server.common.dto.CustomUser;
-import com.chukapoka.server.tree.dto.TreeList;
-import com.chukapoka.server.tree.dto.TreeListResponseDto;
-import com.chukapoka.server.tree.dto.TreeRequestDto;
-import com.chukapoka.server.tree.dto.TreeModifyRequestDto;
+import com.chukapoka.server.tree.dto.*;
 import com.chukapoka.server.tree.entity.Tree;
 import com.chukapoka.server.tree.repository.TreeRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -15,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -28,11 +24,14 @@ public class TreeServiceImpl implements TreeService{
     /** 트리생성 */
     @Override
     @Transactional
-    public Tree createTree(TreeRequestDto treeRequestDto) {
+    public Tree createTree(TreeCreateRequestDto treeRequestDto) {
         Tree tree = new Tree();
         // 클라이언트에서 입력 받을 필요없이 토큰으로 접속후 권한id로 셋팅
         long userId = ((CustomUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
         treeRequestDto.setUpdatedBy(userId);
+
+        // 질문 : 여기를 build를 사용하는게 좋을지 modelMapper를 사용하는게 좋을지??
+        // -> 서버에서 linkId, sendId를 만들어줄꺼라면 build가 좋을꺼같은데...
         BeanUtils.copyProperties(treeRequestDto, tree); // mapper대신 사용할수 있지만 복사할 속성의 수가 적고 속성 이름이 일치하는 경우에 적합
         return treeRepository.save(tree);
     }
@@ -41,43 +40,38 @@ public class TreeServiceImpl implements TreeService{
     @Override
     public TreeListResponseDto treeList() {
         List<TreeList> trees = treeRepository.findAllTrees();
-        if (trees.isEmpty()) {
-            return new TreeListResponseDto(new ArrayList<>());
-        }
         return new TreeListResponseDto(trees);
     }
 
     /** 트리 상세 정보 조회 (상세정보 모델) */
     @Override
-    public Tree treeDetail(Long treeId) {
-
-        return null;
+    public TreeDetailResponseDto treeDetail(Long treeId) {
+        Tree tree = findTreeByIdOrThrow(treeId);
+        // tree entity를 TreeDetailResponseDto로 매핑
+        return modelMapper.map(tree, TreeDetailResponseDto.class);
     }
 
     /** 트리수정 */
     @Override
-    @Transactional // 데이터 변경감지
     public Tree treeModify(Long treeId, TreeModifyRequestDto treeModifyDto) {
         // 트리 아이디로 트리를 찾음
-        Tree tree = treeRepository.findById(treeId)
-                .orElseThrow(() -> new EntityNotFoundException("treeId " + treeId + " 를 찾을 수 없습니다."));
-        updateTreeAttributes(tree, treeModifyDto);
-        return treeRepository.save(tree);
-
+        Tree tree = findTreeByIdOrThrow(treeId);
+        return treeUpdate(tree, treeModifyDto);
     }
 
     /** 트리 삭제 */
     @Override
     @Transactional
-    public void deleteTree(Long treeId) {
-        treeRepository.findById(treeId)
-                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 " + treeId + "입니다."));
+    public void treeDelete(Long treeId) {
+        findTreeByIdOrThrow(treeId);
         treeRepository.deleteById(treeId);
     }
 
 
-    /** 트리필드 정보 업데이트 */
-    private void updateTreeAttributes(Tree tree, TreeModifyRequestDto treeModifyDto) {
+
+    /** 트리필드 정보 업데이트 메서드*/
+    @Transactional // 데이터 변경감지
+    private Tree treeUpdate(Tree tree, TreeModifyRequestDto treeModifyDto) {
         tree.setTitle(treeModifyDto.getTitle());
         tree.setType(treeModifyDto.getType());
         tree.setTreeBgColor(treeModifyDto.getTreeBgColor());
@@ -85,5 +79,12 @@ public class TreeServiceImpl implements TreeService{
         tree.setTreeTopColor(treeModifyDto.getTreeTopColor());
         tree.setTreeItemColor(treeModifyDto.getTreeItemColor());
         tree.setTreeBottomColor(treeModifyDto.getTreeBottomColor());
+        return treeRepository.save(tree);
+    }
+
+    /** treeId Exception 처리 메서드 */
+    private Tree findTreeByIdOrThrow(Long treeId) {
+        return treeRepository.findById(treeId)
+                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 " + treeId + "입니다."));
     }
 }

--- a/src/main/java/com/chukapoka/server/treeItem/entity/TreeItem.java
+++ b/src/main/java/com/chukapoka/server/treeItem/entity/TreeItem.java
@@ -1,0 +1,71 @@
+package com.chukapoka.server.treeItem.entity;
+
+
+import com.chukapoka.server.tree.entity.Tree;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamicUpdate // 데이터의 변경사항이 있는 것만 수정
+@Table(name = "tb_treeItem")
+public class TreeItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "treeItemId")
+    private Long treeItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "treeId", referencedColumnName = "treeId")
+    private Tree treeId;
+
+    /** 편지 제목 */
+    @Column(name = "title")
+    private String title;
+
+    /** 편지 내용*/
+    @Column(name = "content")
+    private String content;
+
+    /** 트라 관련 색상은 String -> enum type으로 상수로 바꿔야 관리가 더 편할것같음 */
+    @Column(name = "treeBgColor", nullable = true)
+    private String treeBgColor;
+
+    @Column(name = "groundColor", nullable = true)
+    private String groundColor;
+
+    @Column(name = "treeTopColor", nullable = true)
+    private String treeTopColor;
+
+    @Column(name = "treeItemColor", nullable = true)
+    private String treeItemColor;
+
+    @Column(name = "treeBottomColor", nullable = true)
+    private String treeBottomColor;
+
+    /** userId가 값임 */
+    @Column(name = "updatedBy")
+    private Long updatedBy;
+
+    /** 생성 시간 */
+    @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+
+
+    @PrePersist
+    public void updatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/com/chukapoka/server/user/dto/UserResponseDto.java
+++ b/src/main/java/com/chukapoka/server/user/dto/UserResponseDto.java
@@ -21,9 +21,4 @@ public class UserResponseDto {
     private Long userId; // unique_userid
     private TokenResponseDto token; // JWT 토큰
 
-    public UserResponseDto(ResultType result, String email, Long userId) {
-        this.result = result;
-        this.email = email;
-        this.userId = userId;
-    }
 }

--- a/src/main/java/com/chukapoka/server/user/repository/UserRepository.java
+++ b/src/main/java/com/chukapoka/server/user/repository/UserRepository.java
@@ -20,8 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndEmailType(String email, String emailType);
 
-    @Override
-    Optional<User> findById(Long aLong);
+    Optional<User> findById(Long id);
 
     // 이메일이 등록되어있는지 이메일과 이메일타입 확인
     boolean existsByEmailAndEmailType(String email, String emailType);

--- a/src/main/java/com/chukapoka/server/user/repository/UserRepository.java
+++ b/src/main/java/com/chukapoka/server/user/repository/UserRepository.java
@@ -25,4 +25,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일이 등록되어있는지 이메일과 이메일타입 확인
     boolean existsByEmailAndEmailType(String email, String emailType);
 
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     # active: prod
-   active: dev
+#   active: dev
 #    active: dev-db
-#     active: local
+     active: local

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     # active: prod
-#   active: dev
+   active: dev
 #    active: dev-db
-     active: local
+#     active: local


### PR DESCRIPTION
## Issues 번호 :

Closes #20 

## 변경, 추가된 코드(설명 등)

### 트리생성 
![image](https://github.com/Chukapoka/server/assets/116487398/eed55de0-2199-4d08-ad01-1069c77531d8)

- CustomUser Id 값을 updateBy 로 저장
- linkId와 sendId 를 어떤 값으로 할지 ???
- - 내 보유 트리 ("MINE")   미부여 트리 (  NOT_YET_SEND) enumType추가 
- 트리 색상 같은 경우 트리마다의 색상 고정된 값을 Enum type으로 따로 뺴서 하면 좋을것 같음

### 트리 리스트 조회 
![image](https://github.com/Chukapoka/server/assets/116487398/4f23ccea-1940-4cb6-9ced-73bf7fe5d963)

- 로그인된 id값과 acceseToken 값으로 조회 가능 

### 트리삭제

![image](https://github.com/Chukapoka/server/assets/116487398/8a0e0639-6d8e-4894-bb1a-ad95730450b1)

- 트리 ID 값과 acceseToken 값으로 삭제 


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: PostgreSQL JDBC 드라이버 및 h2에 대한 라인 주석 변경
- New Feature: SecurityConfig 클래스에 /api/tree 엔드포인트에 대한 권한 설정 추가
- New Feature: TreeType 열거형 추가
- New Feature: TreeController 클래스에 createTree, treeList, deleteTree 함수 추가
- New Feature: Tree 엔티티에 색상 및 트리 유형을 관리하는 새로운 필드 추가
- New Feature: TreeRepository 인터페이스에 findById 및 findByUpdatedBy 메서드 추가
- New Feature: TreeService 인터페이스에 새로운 메서드 추가
- New Feature: TreeServiceImpl 클래스에 트리 생성, 조회, 삭제와 관련된 메서드 추가 및 수정
- Refactor: UserResponseDto 클래스에서 생성자 메서드 삭제
- Refactor: UserRepository findById 함수 시그니처 변경(Long aLong -> Long id)
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->